### PR TITLE
Implement Subject and Exercise models with CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ El backend estará corriendo en: [http://localhost:5000](http://localhost:5000)
 pytest --cov=app backend/tests/
 ```
 
+### 8. Poblar la base de datos con datos de prueba
+
+Para generar información de ejemplo puedes ejecutar el script `seed.py` desde la
+carpeta `backend`:
+
+```bash
+python seed.py
+```
+
+Este comando crea usuarios, materias y ejercicios básicos para iniciar el
+desarrollo.
+
 ---
 
 ## Redis en el Proyecto
@@ -141,3 +153,8 @@ El backend utiliza **Redis** como sistema de almacenamiento en memoria para func
   ```bash
   deactivate
   ```
+
+## 📘 API Reference
+
+Para ver la documentación completa de la API, consulta [API_DOCS.md](backend/API_DOCS.md).
+

--- a/backend/API_DOCS.md
+++ b/backend/API_DOCS.md
@@ -1,0 +1,86 @@
+# PrepMate PAES API Documentation
+
+Esta guía describe los endpoints disponibles en el backend de PrepMate PAES.
+
+## Introducción
+
+La API está construida con **Flask** y utiliza **JSON Web Tokens (JWT)** para la autenticación de usuarios.
+Todas las respuestas se devuelven en formato JSON.
+
+## Autenticación
+
+1. **Registro de estudiante**
+   - **POST /auth/signup**
+   - Crea un usuario con rol `student` y devuelve un `access_token`.
+2. **Registro de administrador**
+   - **POST /auth/signup-admin**
+   - Similar al registro de estudiante pero crea un usuario con rol `admin`.
+3. **Inicio de sesión**
+   - **POST /auth/login**
+   - Requiere `email` y `password` en el cuerpo de la solicitud y devuelve un `access_token` válido.
+4. **Cerrar sesión**
+   - **POST /auth/logout**
+   - Requiere encabezado `Authorization: Bearer <token>` y revoca el token.
+
+El token JWT devuelto debe incluirse en el encabezado `Authorization` para acceder a las rutas protegidas.
+
+## Rutas protegidas
+
+- **GET /protected/me** – Devuelve información básica del usuario autenticado.
+- **POST /profile** – Crea el perfil de un estudiante.
+- **PUT /profile** – Actualiza datos del perfil del estudiante.
+
+Todas requieren el encabezado `Authorization` con el token JWT.
+
+## Materias (Subjects)
+
+| Método | Ruta                     | Descripción               |
+|-------|-------------------------|---------------------------|
+| POST  | `/subjects`             | Crear una nueva materia   |
+| GET   | `/subjects`             | Listar todas las materias |
+| GET   | `/subjects/<id>`        | Obtener una materia       |
+| PUT   | `/subjects/<id>`        | Actualizar una materia    |
+| DELETE| `/subjects/<id>`        | Eliminar una materia      |
+
+Ejemplo de creación:
+
+```bash
+curl -X POST http://localhost:5000/subjects \
+     -H 'Content-Type: application/json' \
+     -d '{"name": "Matemática M1", "description": "desc", "area": "Matemáticas"}'
+```
+
+## Ejercicios (Exercises)
+
+| Método | Ruta                       | Descripción                |
+|-------|---------------------------|----------------------------|
+| POST  | `/exercises`              | Crear un ejercicio         |
+| GET   | `/exercises`              | Listar todos los ejercicios|
+| GET   | `/exercises/<id>`         | Obtener un ejercicio       |
+| PUT   | `/exercises/<id>`         | Actualizar un ejercicio    |
+| DELETE| `/exercises/<id>`         | Eliminar un ejercicio      |
+
+El campo `options` debe ser un objeto JSON con las alternativas (por ejemplo `{"A": "1", "B": "2"}`).
+
+## Manejo de errores
+
+La API devuelve códigos HTTP estándar. Cuando ocurre un error, la respuesta incluye un campo `message` con la descripción del problema.
+
+Ejemplo:
+
+```json
+{"message": "Token de autenticación requerido"}
+```
+
+## Ejemplos de uso con cURL
+
+```bash
+# Login
+token=$(curl -s -X POST http://localhost:5000/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"user@test.com","password":"1234"}' | jq -r '.access_token')
+
+# Acceder a /protected/me
+curl -H "Authorization: Bearer $token" http://localhost:5000/protected/me
+```
+

--- a/backend/app/controllers/__init__.py
+++ b/backend/app/controllers/__init__.py
@@ -1,2 +1,4 @@
 from .auth_controller import auth_bp
 from .protected_controller import protected_bp
+from .subject_controller import subject_bp
+from .exercise_controller import exercise_bp

--- a/backend/app/controllers/exercise_controller.py
+++ b/backend/app/controllers/exercise_controller.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, request, jsonify
+from .. import db
+from ..models import Exercise, Subject
+from ..schemas import ExerciseSchema
+
+exercise_bp = Blueprint('exercise', __name__)
+exercise_schema = ExerciseSchema()
+exercises_schema = ExerciseSchema(many=True)
+
+@exercise_bp.route('/exercises', methods=['POST'])
+def create_exercise():
+    data = request.get_json() or {}
+    try:
+        exercise = exercise_schema.load(data, session=db.session)
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 400
+    db.session.add(exercise)
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': exercise_schema.dump(exercise)}), 201
+
+@exercise_bp.route('/exercises', methods=['GET'])
+def list_exercises():
+    exercises = Exercise.query.all()
+    return jsonify({'status': 'success', 'data': exercises_schema.dump(exercises)}), 200
+
+@exercise_bp.route('/exercises/<int:exercise_id>', methods=['GET'])
+def get_exercise(exercise_id):
+    exercise = Exercise.query.get_or_404(exercise_id)
+    return jsonify({'status': 'success', 'data': exercise_schema.dump(exercise)}), 200
+
+@exercise_bp.route('/exercises/<int:exercise_id>', methods=['PUT'])
+def update_exercise(exercise_id):
+    exercise = Exercise.query.get_or_404(exercise_id)
+    data = request.get_json() or {}
+    try:
+        exercise = exercise_schema.load(data, instance=exercise, session=db.session, partial=True)
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 400
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': exercise_schema.dump(exercise)}), 200
+
+@exercise_bp.route('/exercises/<int:exercise_id>', methods=['DELETE'])
+def delete_exercise(exercise_id):
+    exercise = Exercise.query.get_or_404(exercise_id)
+    db.session.delete(exercise)
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': {'id': exercise_id}}), 200

--- a/backend/app/controllers/subject_controller.py
+++ b/backend/app/controllers/subject_controller.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, request, jsonify
+from .. import db
+from ..models import Subject
+from ..schemas import SubjectSchema
+
+subject_bp = Blueprint('subject', __name__)
+subject_schema = SubjectSchema()
+subjects_schema = SubjectSchema(many=True)
+
+@subject_bp.route('/subjects', methods=['POST'])
+def create_subject():
+    data = request.get_json() or {}
+    try:
+        subject = subject_schema.load(data, session=db.session)
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 400
+    db.session.add(subject)
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': subject_schema.dump(subject)}), 201
+
+@subject_bp.route('/subjects', methods=['GET'])
+def list_subjects():
+    subjects = Subject.query.all()
+    return jsonify({'status': 'success', 'data': subjects_schema.dump(subjects)}), 200
+
+@subject_bp.route('/subjects/<int:subject_id>', methods=['GET'])
+def get_subject(subject_id):
+    subject = Subject.query.get_or_404(subject_id)
+    return jsonify({'status': 'success', 'data': subject_schema.dump(subject)}), 200
+
+@subject_bp.route('/subjects/<int:subject_id>', methods=['PUT'])
+def update_subject(subject_id):
+    subject = Subject.query.get_or_404(subject_id)
+    data = request.get_json() or {}
+    try:
+        subject = subject_schema.load(data, instance=subject, session=db.session, partial=True)
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 400
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': subject_schema.dump(subject)}), 200
+
+@subject_bp.route('/subjects/<int:subject_id>', methods=['DELETE'])
+def delete_subject(subject_id):
+    subject = Subject.query.get_or_404(subject_id)
+    db.session.delete(subject)
+    db.session.commit()
+    return jsonify({'status': 'success', 'data': {'id': subject_id}}), 200

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,5 @@
 from .admin import Admin
 from .student import Student
 from .user import User
+from .subject import Subject
+from .exercise import Exercise

--- a/backend/app/models/exercise.py
+++ b/backend/app/models/exercise.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from .. import db
+
+class Exercise(db.Model):
+    __tablename__ = 'exercises'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    options = db.Column(db.JSON, nullable=False)
+    correct_answer = db.Column(db.String(5), nullable=False)
+    difficulty = db.Column(db.String(50), nullable=True)
+    tags = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    subject_id = db.Column(db.Integer, db.ForeignKey('subjects.id'), nullable=False)
+    subject = db.relationship('Subject', back_populates='exercises')

--- a/backend/app/models/subject.py
+++ b/backend/app/models/subject.py
@@ -1,0 +1,11 @@
+from .. import db
+
+class Subject(db.Model):
+    __tablename__ = 'subjects'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), unique=True, nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    area = db.Column(db.String(120), nullable=True)
+
+    exercises = db.relationship('Exercise', back_populates='subject', cascade='all, delete-orphan')

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,4 +1,4 @@
-from .controllers import auth_bp, protected_bp
+from .controllers import auth_bp, protected_bp, subject_bp, exercise_bp
 from app.controllers.profile_controller import profile_bp
 
 
@@ -6,3 +6,5 @@ def register_routes(app):
     app.register_blueprint(auth_bp, url_prefix='/auth')
     app.register_blueprint(protected_bp, url_prefix='/protected')
     app.register_blueprint(profile_bp)
+    app.register_blueprint(subject_bp)
+    app.register_blueprint(exercise_bp)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,5 @@
 from .student_schema import StudentSchema
 from .user_schema import UserSchema
 from .admin_schema import AdminSchema
+from .subject_schema import SubjectSchema
+from .exercise_schema import ExerciseSchema

--- a/backend/app/schemas/exercise_schema.py
+++ b/backend/app/schemas/exercise_schema.py
@@ -1,0 +1,18 @@
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+from ..models.exercise import Exercise
+
+class ExerciseSchema(SQLAlchemySchema):
+    class Meta:
+        model = Exercise
+        load_instance = True
+        include_fk = True
+
+    id = auto_field(dump_only=True)
+    title = auto_field(required=True)
+    description = auto_field()
+    options = auto_field(required=True)
+    correct_answer = auto_field(required=True)
+    subject_id = auto_field(required=True)
+    difficulty = auto_field()
+    tags = auto_field()
+    created_at = auto_field(dump_only=True)

--- a/backend/app/schemas/subject_schema.py
+++ b/backend/app/schemas/subject_schema.py
@@ -1,0 +1,13 @@
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+from ..models.subject import Subject
+
+class SubjectSchema(SQLAlchemySchema):
+    class Meta:
+        model = Subject
+        load_instance = True
+        include_fk = True
+
+    id = auto_field(dump_only=True)
+    name = auto_field(required=True)
+    description = auto_field()
+    area = auto_field()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,58 @@
+from app import create_app, db
+from app.models import Subject, Exercise, Student, Admin
+
+
+def seed_data():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        if not Subject.query.first():
+            subjects = [
+                Subject(name="Matemática M1", description="Matemáticas", area="Mathematics"),
+                Subject(name="Ciencias", description="Área de ciencias", area="Science"),
+                Subject(name="Competencia Lectora", description="Lectura", area="Language"),
+            ]
+            db.session.add_all(subjects)
+            db.session.commit()
+        else:
+            subjects = Subject.query.all()
+
+        if not Exercise.query.first():
+            ex_list = [
+                Exercise(
+                    title="¿Cuánto es 1+1?",
+                    description="Suma simple",
+                    options={"A": "1", "B": "2", "C": "3", "D": "4"},
+                    correct_answer="B",
+                    subject_id=subjects[0].id,
+                    difficulty="easy",
+                    tags="aritmetica",
+                ),
+                Exercise(
+                    title="¿Cuál es la capital de Francia?",
+                    description="Pregunta de geografía",
+                    options={"A": "Madrid", "B": "Paris", "C": "Roma", "D": "Lisboa"},
+                    correct_answer="B",
+                    subject_id=subjects[1].id,
+                    difficulty="easy",
+                    tags="geografia",
+                ),
+            ]
+            db.session.add_all(ex_list)
+            db.session.commit()
+
+        if not Student.query.first():
+            s = Student(email="student@example.com", role="student", name="Estudiante", rut="1-9", age=18)
+            s.set_password("1234")
+            db.session.add(s)
+        if not Admin.query.first():
+            a = Admin(email="admin@example.com", role="admin", name="Admin", rut="2-7", age=30, accepted_terms=True)
+            a.set_password("admin")
+            db.session.add(a)
+        db.session.commit()
+
+        print("Datos de prueba creados")
+
+
+if __name__ == "__main__":
+    seed_data()

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -1,0 +1,36 @@
+from .conftest import BaseTestCase
+from flask import json
+
+class TestExerciseEndpoints(BaseTestCase):
+    def test_exercise_crud(self):
+        with self.app.app_context():
+            # create subject first
+            s_res = self.client.post('/subjects', json={"name": "Ciencias", "description": "desc", "area": "Science"})
+            subject_id = json.loads(s_res.data)['data']['id']
+
+            payload = {
+                "title": "Pregunta 1",
+                "description": "desc",
+                "options": {"A": "1", "B": "2", "C": "3", "D": "4"},
+                "correct_answer": "A",
+                "subject_id": subject_id,
+                "difficulty": "easy",
+                "tags": "tag1"
+            }
+            res = self.client.post('/exercises', json=payload)
+            self.assertEqual(res.status_code, 201)
+            data = json.loads(res.data)
+            exercise_id = data['data']['id']
+
+            res = self.client.get('/exercises')
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(len(json.loads(res.data)['data']), 1)
+
+            res = self.client.put(f'/exercises/{exercise_id}', json={"difficulty": "medium"})
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(json.loads(res.data)['data']['difficulty'], 'medium')
+
+            res = self.client.delete(f'/exercises/{exercise_id}')
+            self.assertEqual(res.status_code, 200)
+            res = self.client.get(f'/exercises/{exercise_id}')
+            self.assertEqual(res.status_code, 404)

--- a/backend/tests/test_subject.py
+++ b/backend/tests/test_subject.py
@@ -1,0 +1,30 @@
+from .conftest import BaseTestCase
+from flask import json
+
+class TestSubjectEndpoints(BaseTestCase):
+    def test_subject_crud(self):
+        with self.app.app_context():
+            payload = {"name": "Matemática", "description": "desc", "area": "Math"}
+            res = self.client.post('/subjects', json=payload)
+            self.assertEqual(res.status_code, 201)
+            data = json.loads(res.data)
+            subject_id = data['data']['id']
+
+            res = self.client.get('/subjects')
+            self.assertEqual(res.status_code, 200)
+            data_list = json.loads(res.data)
+            self.assertEqual(len(data_list['data']), 1)
+
+            res = self.client.get(f'/subjects/{subject_id}')
+            self.assertEqual(res.status_code, 200)
+
+            res = self.client.put(f'/subjects/{subject_id}', json={"name": "Mate"})
+            self.assertEqual(res.status_code, 200)
+            data = json.loads(res.data)
+            self.assertEqual(data['data']['name'], 'Mate')
+
+            res = self.client.delete(f'/subjects/{subject_id}')
+            self.assertEqual(res.status_code, 200)
+
+            res = self.client.get(f'/subjects/{subject_id}')
+            self.assertEqual(res.status_code, 404)


### PR DESCRIPTION
## Summary
- create Subject and Exercise models
- add Marshmallow schemas for both entities
- implement CRUD controllers and register routes
- provide endpoint unit tests for the new resources
- add seed.py to populate test data on demand
- write API_DOCS.md with usage information
- link API documentation from README