### PR TITLE
Update signup page

### DIFF
--- a/backend/app/controllers/auth_controller.py
+++ b/backend/app/controllers/auth_controller.py
@@ -39,28 +39,25 @@ def signup():
     if User.query.filter_by(email=data['email']).first() is not None:
         return jsonify({'message': 'Email already registered'}), 400
 
-    # Crear usuario base con rol student
-    user = User(
-        email=data['email'],
-        role='student'
-    )
-    user.set_password(data['password'])
-    db.session.add(user)
-    db.session.flush()  # Para obtener user.id
-
-    # Crear instancia Student enlazada al User
+    # Crear instancia Student (hereda de User) directamente
     student = Student(
-        id=user.id,  # Hereda el id del User
+        email=data['email'],
+        role='student',
         name=data['name'],
         rut=data['rut'],
         age=data['age'],
         accepted_terms=data.get('terms', False)
     )
+    student.set_password(data['password'])
     db.session.add(student)
     db.session.commit()
 
-    token = create_access_token(identity=str(user.id))
-    return jsonify({'access_token': token, 'user': user_schema.dump(user), 'student': student_schema.dump(student)}), 201
+    token = create_access_token(identity=str(student.id))
+    return jsonify({
+        'access_token': token,
+        'user': user_schema.dump(student),
+        'student': student_schema.dump(student)
+    }), 201
 
 @auth_bp.route('/signup-admin', methods=['POST'])
 def signup_admin():
@@ -72,27 +69,25 @@ def signup_admin():
     if User.query.filter_by(email=data['email']).first() is not None:
         return jsonify({'message': 'Email already registered'}), 400
 
-    user = User(
-        email=data['email'],
-        role='admin'
-    )
-    user.set_password(data['password'])
-    db.session.add(user)
-    db.session.flush()  # Save user and retrieve user.id without committing
-
-    # Crear instancia Admin enlazada al User
+    # Crear instancia Admin directamente
     admin = Admin(
-        id=user.id,  # Hereda el id del User
+        email=data['email'],
+        role='admin',
         name=data['name'],
         rut=data['rut'],
         age=data['age'],
         accepted_terms=data.get('terms', False)
     )
+    admin.set_password(data['password'])
     db.session.add(admin)
     db.session.commit()
 
-    token = create_access_token(identity=str(user.id))
-    return jsonify({'access_token': token, 'user': user_schema.dump(user), 'admin': admin_schema.dump(admin)}), 201
+    token = create_access_token(identity=str(admin.id))
+    return jsonify({
+        'access_token': token,
+        'user': user_schema.dump(admin),
+        'admin': admin_schema.dump(admin)
+    }), 201
 
 @auth_bp.route('/logout', methods=['POST'])
 @jwt_required

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -10,7 +10,10 @@ class User(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
+    # Werkzeug 3.x usa scrypt por defecto para generar los hashes, los cuales
+    # superan los 128 caracteres. Aumentamos el tamaño del campo para evitar
+    # errores de truncamiento al registrar usuarios.
+    password_hash = db.Column(db.String(256), nullable=False)
     role = db.Column(db.String(20), nullable=False, default='student')  # 'student' o 'admin'
     is_active = db.Column(db.Boolean, default=True)
 

--- a/backend/migrations/versions/0442bc4bd2ba_check.py
+++ b/backend/migrations/versions/0442bc4bd2ba_check.py
@@ -22,7 +22,9 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=120), nullable=False),
     sa.Column('email', sa.String(length=120), nullable=False),
-    sa.Column('password_hash', sa.String(length=128), nullable=False),
+    # El hash generado por Werkzeug puede superar los 128 caracteres,
+    # por lo que ampliamos el tamaño del campo a 256.
+    sa.Column('password_hash', sa.String(length=256), nullable=False),
     sa.Column('rut', sa.String(length=20), nullable=False),
     sa.Column('age', sa.Integer(), nullable=False),
     sa.Column('accepted_terms', sa.Boolean(), nullable=True),

--- a/backend/migrations/versions/babfec4ccd06_modelo_user_con_roles_y_herencia_.py
+++ b/backend/migrations/versions/babfec4ccd06_modelo_user_con_roles_y_herencia_.py
@@ -21,7 +21,8 @@ def upgrade():
     op.create_table('users',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('email', sa.String(length=120), nullable=False),
-    sa.Column('password_hash', sa.String(length=128), nullable=False),
+    # El hash de contraseña ahora puede exceder 128 caracteres
+    sa.Column('password_hash', sa.String(length=256), nullable=False),
     sa.Column('role', sa.String(length=20), nullable=False),
     sa.Column('is_active', sa.Boolean(), nullable=True),
     sa.PrimaryKeyConstraint('id'),

--- a/frontend/prepmate/src/app/pages/signup/signup.page.html
+++ b/frontend/prepmate/src/app/pages/signup/signup.page.html
@@ -8,6 +8,33 @@
 
     <form [formGroup]="signupForm" (ngSubmit)="onSubmit()" class="space-y-4">
       <ion-item class="rounded-lg dark:bg-slate-700">
+        <ion-label position="floating" class="text-sm">Nombre</ion-label>
+        <ion-input
+          type="text"
+          formControlName="name"
+          class="ion-input-custom w-full text-text-light dark:text-white"
+        ></ion-input>
+      </ion-item>
+
+      <ion-item class="rounded-lg dark:bg-slate-700">
+        <ion-label position="floating" class="text-sm">RUT</ion-label>
+        <ion-input
+          type="text"
+          formControlName="rut"
+          class="ion-input-custom w-full text-text-light dark:text-white"
+        ></ion-input>
+      </ion-item>
+
+      <ion-item class="rounded-lg dark:bg-slate-700">
+        <ion-label position="floating" class="text-sm">Edad</ion-label>
+        <ion-input
+          type="number"
+          formControlName="age"
+          class="ion-input-custom w-full text-text-light dark:text-white"
+        ></ion-input>
+      </ion-item>
+
+      <ion-item class="rounded-lg dark:bg-slate-700">
         <ion-label position="floating" class="text-sm">Correo electrónico</ion-label>
         <ion-input
           type="email"

--- a/frontend/prepmate/src/app/pages/signup/signup.page.ts
+++ b/frontend/prepmate/src/app/pages/signup/signup.page.ts
@@ -20,6 +20,9 @@ export class SignupPage {
 
   constructor(private fb: FormBuilder, private router: Router, private auth: AuthService, private store: AuthStore) {
     this.signupForm = this.fb.group({
+      name: ['', Validators.required],
+      rut: ['', Validators.required],
+      age: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
       confirmPassword: ['', Validators.required],
@@ -35,8 +38,8 @@ export class SignupPage {
       return;
     }
 
-    const { email, password, terms } = this.signupForm.value;
-    this.auth.signup({ email, password, terms }).subscribe({
+    const { name, rut, age, email, password, terms } = this.signupForm.value;
+    this.auth.signup({ name, rut, age: Number(age), email, password, terms }).subscribe({
       next: (res) => {
         this.store.setSession(res);
         this.router.navigate(['/profile']);


### PR DESCRIPTION
## Summary
- align signup page with backend `/auth/signup` requirements by adding fields for name, rut and age
- allow longer password hashes and create student/admin rows directly