### PR TITLE
Implement profile GET endpoint and add dark mode toggle

### DIFF
--- a/backend/API_DOCS.md
+++ b/backend/API_DOCS.md
@@ -29,6 +29,7 @@ El token JWT devuelto debe incluirse en el encabezado `Authorization` para acced
 - **GET /protected/me** – Devuelve información básica del usuario autenticado.
 - **POST /profile** – Crea el perfil de un estudiante.
 - **PUT /profile** – Actualiza datos del perfil del estudiante.
+- **GET /profile** – Obtiene el perfil del estudiante autenticado.
 
 Todas requieren el encabezado `Authorization` con el token JWT.
 

--- a/backend/app/controllers/profile_controller.py
+++ b/backend/app/controllers/profile_controller.py
@@ -53,3 +53,15 @@ def update_profile():
             setattr(student, field, data[field])
     db.session.commit()
     return jsonify({'student': student_schema.dump(student)}), 200
+
+
+@profile_bp.route('/profile', methods=['GET'])
+@jwt_required
+def get_profile():
+    user = g.user
+    if user.role != 'student':
+        return jsonify({'message': 'Solo los estudiantes pueden ver perfil'}), 403
+    student = Student.query.filter_by(id=user.id).first()
+    if not student:
+        return jsonify({'message': 'Perfil no encontrado'}), 404
+    return jsonify({'student': student_schema.dump(student)}), 200

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -34,6 +34,27 @@ class TestProfileEndpoints(BaseTestCase):
             res = self.client.put('/profile', json={'name': 'X'})
             self.assertEqual(res.status_code, 401)
 
+    def test_get_profile_success(self):
+        with self.app.app_context():
+            res = self.client.get('/profile',
+                headers={'Authorization': f'Bearer {self.token}'}
+            )
+            self.assertEqual(res.status_code, 200)
+            data = json.loads(res.data)
+            self.assertEqual(data['student']['name'], 'Profile')
+
+    def test_get_profile_not_found(self):
+        with self.app.app_context():
+            user = UserFactory.create_user(email='no_profile@test.com')
+            token = create_access_token(identity=str(user.id))
+            res = self.client.get('/profile', headers={'Authorization': f'Bearer {token}'})
+            self.assertEqual(res.status_code, 404)
+
+    def test_get_profile_requires_auth(self):
+        with self.app.app_context():
+            res = self.client.get('/profile')
+            self.assertEqual(res.status_code, 401)
+
     def test_create_profile_success(self):
         with self.app.app_context():
             # Crear un usuario sin perfil para probar creación

--- a/frontend/prepmate/src/app/pages/profile/profile-view.page.html
+++ b/frontend/prepmate/src/app/pages/profile/profile-view.page.html
@@ -52,4 +52,11 @@
     <div *ngIf="successMsg" class="text-green-600 dark:text-green-400 text-center mt-4">{{ successMsg }}</div>
     <div *ngIf="errorMsg" class="text-red-500 text-center mt-4">{{ errorMsg }}</div>
   </div>
+
+  <button
+    class="mt-6 text-sm underline text-text-light dark:text-text-dark hover:text-primary transition"
+    (click)="toggleDarkMode()"
+  >
+    Cambiar a modo {{ isDark ? 'claro' : 'oscuro' }}
+  </button>
 </div>

--- a/frontend/prepmate/src/app/pages/profile/profile-view.page.ts
+++ b/frontend/prepmate/src/app/pages/profile/profile-view.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ProfileService } from '../../services/profile.service';
+import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'app-profile-view',
@@ -15,10 +16,12 @@ export class ProfileViewPage implements OnInit {
   loading = false;
   errorMsg = '';
   successMsg = '';
+  isDark = false;
 
   constructor(
     private profile: ProfileService,
-    private fb: FormBuilder
+    private fb: FormBuilder,
+    private theme: ThemeService
   ) {
     this.profileForm = this.fb.group({
       name: ['', Validators.required],
@@ -28,6 +31,7 @@ export class ProfileViewPage implements OnInit {
       region: [''],
       age: ['', Validators.required]
     });
+    this.isDark = this.theme.isDarkMode();
   }
 
   ngOnInit(): void {
@@ -60,6 +64,11 @@ export class ProfileViewPage implements OnInit {
     this.profileForm.patchValue(this.user);
     this.successMsg = '';
     this.errorMsg = '';
+  }
+
+  toggleDarkMode() {
+    this.theme.toggleTheme();
+    this.isDark = this.theme.isDarkMode();
   }
 
   onSubmit() {


### PR DESCRIPTION
## Summary
- add GET `/profile` endpoint
- document new profile endpoint
- extend profile page with dark mode toggle
- support theme service usage in profile view
- test profile retrieval
