### PR TITLE
Frontend improvements with notifications and security

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,6 +2,8 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_jwt_extended import JWTManager
+from flask_cors import CORS
+import os
 from .config.config import Config
 
 db = SQLAlchemy()
@@ -14,12 +16,8 @@ def create_app(config_override=None):
     if config_override:
         app.config.update(config_override)
 
-    @app.after_request
-    def add_cors_headers(response):
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type,Authorization'
-        response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,OPTIONS'
-        return response
+    # Configurar CORS de forma segura usando flask-cors
+    CORS(app, origins=os.getenv('CLIENT_URL', '*'), supports_credentials=True)
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/backend/app/api_routes/assignment_routes.py
+++ b/backend/app/api_routes/assignment_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
 from app.models.assignment import Assignment
+from app.models.exercise import Exercise
 from app import db
 
 assignment_bp = Blueprint('assignment_api', __name__)
@@ -17,3 +18,19 @@ def submit_assignment():
     db.session.add(assignment)
     db.session.commit()
     return jsonify({"message": "Respuesta registrada"}), 201
+
+
+@assignment_bp.route('/api/assignments', methods=['GET'])
+def list_assignments():
+    user_id = request.args.get('user_id', type=int)
+    subject_id = request.args.get('subject_id', type=int)
+    query = Assignment.query
+    if user_id:
+        query = query.filter_by(user_id=user_id)
+    if subject_id:
+        query = query.join(Exercise, Assignment.exercise_id == Exercise.id).filter(Exercise.subject_id == subject_id)
+    assignments = query.order_by(Assignment.created_at.desc()).all()
+    return (
+        jsonify([a.to_dict() for a in assignments]),
+        200,
+    )

--- a/backend/app/controllers/exercise_controller.py
+++ b/backend/app/controllers/exercise_controller.py
@@ -3,6 +3,7 @@ from .. import db
 from ..models import Exercise, Subject
 from ..schemas import ExerciseSchema
 from ..services.auth_middleware import jwt_required, admin_required
+import bleach
 
 exercise_bp = Blueprint('exercise', __name__)
 exercise_schema = ExerciseSchema()
@@ -13,6 +14,8 @@ exercises_schema = ExerciseSchema(many=True)
 @admin_required
 def create_exercise():
     data = request.get_json() or {}
+    clean = lambda s: bleach.clean(s, strip=True) if isinstance(s, str) else s
+    data = {k: clean(v) for k, v in data.items()}
     try:
         exercise = exercise_schema.load(data, session=db.session)
     except Exception as e:
@@ -37,6 +40,8 @@ def get_exercise(exercise_id):
 def update_exercise(exercise_id):
     exercise = Exercise.query.get_or_404(exercise_id)
     data = request.get_json() or {}
+    clean = lambda s: bleach.clean(s, strip=True) if isinstance(s, str) else s
+    data = {k: clean(v) for k, v in data.items()}
     try:
         exercise = exercise_schema.load(data, instance=exercise, session=db.session, partial=True)
     except Exception as e:

--- a/backend/app/controllers/profile_controller.py
+++ b/backend/app/controllers/profile_controller.py
@@ -3,6 +3,7 @@ from ..services.auth_middleware import jwt_required
 from ..models import Student
 from ..schemas import StudentSchema
 from .. import db
+import bleach
 
 profile_bp = Blueprint('profile', __name__)
 student_schema = StudentSchema()
@@ -20,15 +21,16 @@ def create_profile():
     # Verificar si ya existe perfil
     if Student.query.filter_by(id=user.id).first():
         return jsonify({'message': 'El perfil ya existe'}), 400
+    clean = lambda s: bleach.clean(s, strip=True) if isinstance(s, str) else s
     db.session.execute(
         Student.__table__.insert().values(
             id=user.id,
-            name=data['name'],
-            rut=data['rut'],
+            name=clean(data['name']),
+            rut=clean(data['rut']),
             age=data['age'],
-            colegio=data['colegio'],
-            comuna=data['comuna'],
-            region=data['region'],
+            colegio=clean(data['colegio']),
+            comuna=clean(data['comuna']),
+            region=clean(data['region']),
             accepted_terms=data.get('accepted_terms', False)
         )
     )
@@ -48,9 +50,10 @@ def update_profile():
     student = Student.query.filter_by(id=user.id).first()
     if not student:
         return jsonify({'message': 'Perfil no encontrado'}), 404
+    clean = lambda s: bleach.clean(s, strip=True) if isinstance(s, str) else s
     for field in ['name', 'rut', 'age', 'colegio', 'comuna', 'region']:
         if field in data:
-            setattr(student, field, data[field])
+            setattr(student, field, clean(data[field]))
     db.session.commit()
     return jsonify({'student': student_schema.dump(student)}), 200
 

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -13,3 +13,14 @@ class Assignment(db.Model):
 
     user = db.relationship('User')
     exercise = db.relationship('Exercise')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'exercise_id': self.exercise_id,
+            'respuesta_entregada': self.respuesta_entregada,
+            'correcta': self.correcta,
+            'created_at': self.created_at.isoformat(),
+            'subject_id': self.exercise.subject_id if self.exercise else None,
+        }

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,5 +1,5 @@
 from .. import db
-from werkzeug.security import generate_password_hash, check_password_hash
+import bcrypt
 
 class User(db.Model):
     __tablename__ = 'users'
@@ -18,7 +18,7 @@ class User(db.Model):
     is_active = db.Column(db.Boolean, default=True)
 
     def set_password(self, password: str) -> None:
-        self.password_hash = generate_password_hash(password)
+        self.password_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
     def check_password(self, password: str) -> bool:
-        return check_password_hash(self.password_hash, password)
+        return bcrypt.checkpw(password.encode('utf-8'), self.password_hash.encode('utf-8'))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,6 @@ typing_extensions==4.14.0
 Werkzeug==3.1.3
 pytest==7.4.2
 pytest-cov==4.1.0
+flask-cors==6.0.1
+bcrypt==4.3.0
+bleach==6.2.0

--- a/backend/tests/test_assignment_api.py
+++ b/backend/tests/test_assignment_api.py
@@ -34,3 +34,9 @@ class TestAssignmentAPI(BaseTestCase):
             }
             res = self.client.post('/api/assignments', json=assign_payload)
             self.assertEqual(res.status_code, 201)
+
+            res = self.client.get(f'/api/assignments?user_id={student.id}&subject_id={subject_id}')
+            self.assertEqual(res.status_code, 200)
+            data = json.loads(res.data)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]['exercise_id'], exercise_id)

--- a/frontend/prepmate/src/app/app-routing.module.ts
+++ b/frontend/prepmate/src/app/app-routing.module.ts
@@ -38,6 +38,11 @@ const routes: Routes = [
     path: 'exercise/:materia',
     loadChildren: () => import('./pages/exercise/exercise.module').then(m => m.ExercisePageModule),
     canActivate: [AuthGuard]
+  },
+  {
+    path: 'session/:materia',
+    loadChildren: () => import('./pages/session/session.module').then(m => m.SessionPageModule),
+    canActivate: [AuthGuard]
   }
 ];
 

--- a/frontend/prepmate/src/app/app.component.html
+++ b/frontend/prepmate/src/app/app.component.html
@@ -1,2 +1,4 @@
+<app-error-banner></app-error-banner>
+<app-notification-banner></app-notification-banner>
 <app-navbar></app-navbar>
 <router-outlet></router-outlet>

--- a/frontend/prepmate/src/app/app.component.ts
+++ b/frontend/prepmate/src/app/app.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ThemeService } from './services/theme.service';
+import { AuthStore } from './store/auth.store';
+import { NotificationService } from './services/notification.service';
 
 @Component({
   selector: 'app-root',
@@ -7,6 +9,18 @@ import { ThemeService } from './services/theme.service';
   styleUrls: ['app.component.scss'],
   standalone: false,
 })
-export class AppComponent {
-  constructor(private themeService: ThemeService) {}
+export class AppComponent implements OnInit {
+  constructor(
+    private themeService: ThemeService,
+    private store: AuthStore,
+    private notifications: NotificationService
+  ) {}
+
+  ngOnInit() {
+    this.store.token$.subscribe(token => {
+      if (token) {
+        this.notifications.fetch();
+      }
+    });
+  }
 }

--- a/frontend/prepmate/src/app/components/components.module.ts
+++ b/frontend/prepmate/src/app/components/components.module.ts
@@ -3,11 +3,14 @@ import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { LogoComponent } from './logo/logo.component';
 import { NavbarComponent } from './navbar/navbar.component';
+import { ErrorBannerComponent } from './error-banner/error-banner.component';
+import { NotificationBannerComponent } from './notification-banner/notification-banner.component';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
-  declarations: [LogoComponent, NavbarComponent],
+  declarations: [LogoComponent, NavbarComponent, ErrorBannerComponent, NotificationBannerComponent],
   imports: [CommonModule, RouterModule, IonicModule],
-  exports: [LogoComponent, NavbarComponent]
+  exports: [LogoComponent, NavbarComponent, ErrorBannerComponent, NotificationBannerComponent]
 })
 export class ComponentsModule {}
+

--- a/frontend/prepmate/src/app/components/error-banner/error-banner.component.html
+++ b/frontend/prepmate/src/app/components/error-banner/error-banner.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="(message$ | async) as msg" class="error-banner bg-red-500 text-white px-4 py-2 flex items-center justify-between">
+  <span>{{ msg }}</span>
+  <button (click)="close()" aria-label="Cerrar" class="text-xl leading-none">&times;</button>
+</div>

--- a/frontend/prepmate/src/app/components/error-banner/error-banner.component.scss
+++ b/frontend/prepmate/src/app/components/error-banner/error-banner.component.scss
@@ -1,0 +1,3 @@
+.error-banner {
+  @apply fixed top-0 left-0 w-full z-50 shadow-lg;
+}

--- a/frontend/prepmate/src/app/components/error-banner/error-banner.component.ts
+++ b/frontend/prepmate/src/app/components/error-banner/error-banner.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { ErrorService } from '../../services/error.service';
+
+@Component({
+  selector: 'app-error-banner',
+  templateUrl: './error-banner.component.html',
+  styleUrls: ['./error-banner.component.scss'],
+  standalone: false
+})
+export class ErrorBannerComponent {
+  message$ = this.error.message$;
+
+  constructor(private error: ErrorService) {}
+
+  close() {
+    this.error.clear();
+  }
+}

--- a/frontend/prepmate/src/app/components/navbar/navbar.component.html
+++ b/frontend/prepmate/src/app/components/navbar/navbar.component.html
@@ -8,21 +8,41 @@
       [class.hidden]="!menuOpen"
       class="absolute left-0 top-full w-full bg-white dark:bg-slate-800 md:static md:flex md:gap-6 md:w-auto md:items-center md:space-x-6 md:mt-0 shadow md:shadow-none"
     >
-      <li><a routerLink="/home" class="block px-4 py-2 hover:underline">Inicio</a></li>
-      <li *ngIf="token$ | async">
-        <a routerLink="/subjects" class="block px-4 py-2 hover:underline">Materias</a>
+      <li>
+        <a routerLink="/home" class="flex items-center gap-1 px-4 py-2 hover:underline">
+          <ion-icon name="home-outline"></ion-icon>
+          Inicio
+        </a>
       </li>
       <li *ngIf="token$ | async">
-        <a routerLink="/profile/view" class="block px-4 py-2 hover:underline">Perfil</a>
+        <a routerLink="/subjects" class="flex items-center gap-1 px-4 py-2 hover:underline">
+          <ion-icon name="book-outline"></ion-icon>
+          Materias
+        </a>
+      </li>
+      <li *ngIf="token$ | async">
+        <a routerLink="/profile/view" class="flex items-center gap-1 px-4 py-2 hover:underline">
+          <ion-icon name="person-circle-outline"></ion-icon>
+          Perfil
+        </a>
       </li>
       <li *ngIf="(token$ | async) === null">
-        <a routerLink="/login" class="block px-4 py-2 hover:underline">Entrar</a>
+        <a routerLink="/login" class="flex items-center gap-1 px-4 py-2 hover:underline">
+          <ion-icon name="log-in-outline"></ion-icon>
+          Entrar
+        </a>
       </li>
       <li *ngIf="(token$ | async) === null">
-        <a routerLink="/signup" class="block px-4 py-2 hover:underline">Registro</a>
+        <a routerLink="/signup" class="flex items-center gap-1 px-4 py-2 hover:underline">
+          <ion-icon name="person-add-outline"></ion-icon>
+          Registro
+        </a>
       </li>
       <li *ngIf="token$ | async">
-        <button (click)="logout()" class="w-full text-left px-4 py-2 hover:underline">Salir</button>
+        <button (click)="logout()" class="flex items-center gap-1 w-full text-left px-4 py-2 hover:underline">
+          <ion-icon name="log-out-outline"></ion-icon>
+          Salir
+        </button>
       </li>
     </ul>
   </div>

--- a/frontend/prepmate/src/app/components/navbar/navbar.component.scss
+++ b/frontend/prepmate/src/app/components/navbar/navbar.component.scss
@@ -4,4 +4,7 @@
 
 ul {
   @apply md:flex md:relative md:top-auto md:left-auto;
+  li a, li button {
+    @apply transition-colors duration-200;
+  }
 }

--- a/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.html
+++ b/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="(message$ | async) as msg" class="notification-banner bg-primary text-white px-4 py-2 flex items-center justify-between">
+  <span>{{ msg }}</span>
+  <button (click)="close()" aria-label="Cerrar" class="text-xl leading-none">&times;</button>
+</div>

--- a/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.scss
+++ b/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.scss
@@ -1,0 +1,3 @@
+.notification-banner {
+  @apply fixed top-10 left-0 w-full z-40 shadow-lg;
+}

--- a/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.ts
+++ b/frontend/prepmate/src/app/components/notification-banner/notification-banner.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { NotificationService } from '../../services/notification.service';
+
+@Component({
+  selector: 'app-notification-banner',
+  templateUrl: './notification-banner.component.html',
+  styleUrls: ['./notification-banner.component.scss'],
+  standalone: false
+})
+export class NotificationBannerComponent {
+  message$ = this.notification.message$;
+
+  constructor(private notification: NotificationService) {}
+
+  close() {
+    this.notification.clear();
+  }
+}

--- a/frontend/prepmate/src/app/data/regions.ts
+++ b/frontend/prepmate/src/app/data/regions.ts
@@ -1,0 +1,29 @@
+export interface Region {
+  name: string;
+  communes: string[];
+}
+
+export const REGIONS: Region[] = [
+  {
+    name: 'Región Metropolitana',
+    communes: [
+      'Cerrillos', 'Cerro Navia', 'Conchalí', 'El Bosque', 'Estación Central',
+      'Huechuraba', 'Independencia', 'La Cisterna', 'La Florida', 'La Granja',
+      'La Pintana', 'La Reina', 'Las Condes', 'Lo Barnechea', 'Lo Espejo',
+      'Lo Prado', 'Macul', 'Maipú', 'Ñuñoa', 'Pedro Aguirre Cerda',
+      'Peñalolén', 'Providencia', 'Pudahuel', 'Quilicura', 'Quinta Normal',
+      'Recoleta', 'Renca', 'San Joaquín', 'San Miguel', 'San Ramón',
+      'Santiago', 'Vitacura'
+    ]
+  },
+  {
+    name: 'Valparaíso',
+    communes: [
+      'Valparaíso', 'Viña del Mar', 'Concón', 'Quilpué', 'Villa Alemana'
+    ]
+  },
+  {
+    name: 'Biobío',
+    communes: ['Concepción', 'Coronel', 'Talcahuano', 'Chiguayante']
+  }
+];

--- a/frontend/prepmate/src/app/pages/login/login.page.html
+++ b/frontend/prepmate/src/app/pages/login/login.page.html
@@ -14,6 +14,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="loginForm.get('email')?.invalid && loginForm.get('email')?.touched" class="text-xs text-red-500">Email inválido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Contraseña</ion-label>
@@ -24,6 +25,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="loginForm.get('password')?.invalid && loginForm.get('password')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-button
         expand="block"

--- a/frontend/prepmate/src/app/pages/login/login.page.ts
+++ b/frontend/prepmate/src/app/pages/login/login.page.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { AuthStore } from '../../store/auth.store';
+import { ErrorService } from '../../services/error.service';
 
 @Component({
   selector: 'app-login',
@@ -13,7 +14,13 @@ import { AuthStore } from '../../store/auth.store';
 export class LoginPage {
   loginForm: FormGroup;
 
-  constructor(private fb: FormBuilder, private auth: AuthService, private store: AuthStore, private router: Router) {
+  constructor(
+    private fb: FormBuilder,
+    private auth: AuthService,
+    private store: AuthStore,
+    private router: Router,
+    private error: ErrorService
+  ) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
@@ -22,7 +29,7 @@ export class LoginPage {
 
   onSubmit() {
     if (this.loginForm.invalid) {
-      console.log('❌ Formulario inválido');
+      this.error.show('Por favor completa los campos requeridos.');
       return;
     }
 
@@ -32,7 +39,7 @@ export class LoginPage {
         this.router.navigate(['/subjects']);
       },
       error: (err) => {
-        console.error('❌ Error en login', err);
+        this.error.handle(err, 'Credenciales inválidas o error de conexión.');
       }
     });
   }

--- a/frontend/prepmate/src/app/pages/profile/profile-view.page.html
+++ b/frontend/prepmate/src/app/pages/profile/profile-view.page.html
@@ -35,11 +35,15 @@
       </ion-item>
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Comuna</ion-label>
-        <ion-input type="text" formControlName="comuna" class="ion-input-custom w-full text-text-light dark:text-white"></ion-input>
+        <ion-select formControlName="comuna" interface="action-sheet" class="w-full">
+          <ion-select-option *ngFor="let c of communes" [value]="c">{{ c }}</ion-select-option>
+        </ion-select>
       </ion-item>
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Región</ion-label>
-        <ion-input type="text" formControlName="region" class="ion-input-custom w-full text-text-light dark:text-white"></ion-input>
+        <ion-select formControlName="region" interface="action-sheet" class="w-full" (ionChange)="onRegionChange($event.detail.value)">
+          <ion-select-option *ngFor="let r of regions" [value]="r.name">{{ r.name }}</ion-select-option>
+        </ion-select>
       </ion-item>
       <div class="flex gap-2 mt-4">
         <ion-button expand="block" type="submit" [disabled]="profileForm.invalid || loading" class="ion-button-custom">Guardar</ion-button>

--- a/frontend/prepmate/src/app/pages/profile/profile-view.page.ts
+++ b/frontend/prepmate/src/app/pages/profile/profile-view.page.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ProfileService } from '../../services/profile.service';
 import { ThemeService } from '../../services/theme.service';
+import { REGIONS, Region } from '../../data/regions';
 
 @Component({
   selector: 'app-profile-view',
@@ -17,6 +18,8 @@ export class ProfileViewPage implements OnInit {
   errorMsg = '';
   successMsg = '';
   isDark = false;
+  regions: Region[] = REGIONS;
+  communes: string[] = [];
 
   constructor(
     private profile: ProfileService,
@@ -31,6 +34,7 @@ export class ProfileViewPage implements OnInit {
       region: [''],
       age: ['', Validators.required]
     });
+    this.profileForm.get('region')?.valueChanges.subscribe(name => this.onRegionChange(name));
     this.isDark = this.theme.isDarkMode();
   }
 
@@ -44,10 +48,13 @@ export class ProfileViewPage implements OnInit {
       next: (res) => {
         this.user = res.student;
         this.profileForm.patchValue(this.user);
+        if (this.user.region) {
+          this.onRegionChange(this.user.region);
+        }
         this.loading = false;
       },
-      error: () => {
-        this.errorMsg = 'No se pudo cargar el perfil.';
+      error: (err) => {
+        this.errorMsg = err.error?.message || 'No se pudo cargar el perfil.';
         this.loading = false;
       }
     });
@@ -84,10 +91,18 @@ export class ProfileViewPage implements OnInit {
         this.successMsg = 'Perfil actualizado correctamente.';
         this.loading = false;
       },
-      error: () => {
-        this.errorMsg = 'Error al actualizar el perfil.';
+      error: (err) => {
+        this.errorMsg = err.error?.message || 'Error al actualizar el perfil.';
         this.loading = false;
       }
     });
+  }
+
+  onRegionChange(name: string) {
+    const region = this.regions.find(r => r.name === name);
+    this.communes = region ? region.communes : [];
+    if (!region) {
+      this.profileForm.get('comuna')?.setValue('');
+    }
   }
 }

--- a/frontend/prepmate/src/app/pages/profile/profile.page.html
+++ b/frontend/prepmate/src/app/pages/profile/profile.page.html
@@ -12,16 +12,20 @@
       <div *ngIf="profileForm.get('colegio')?.invalid && profileForm.get('colegio')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-item class="ion-item-custom">
-        <ion-label position="floating" class="text-sm">Comuna</ion-label>
-        <ion-input type="text" formControlName="comuna" class="ion-input-custom w-full text-text-light dark:text-white"></ion-input>
-      </ion-item>
-      <div *ngIf="profileForm.get('comuna')?.invalid && profileForm.get('comuna')?.touched" class="text-xs text-red-500">Campo requerido</div>
-
-      <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Región</ion-label>
-        <ion-input type="text" formControlName="region" class="ion-input-custom w-full text-text-light dark:text-white"></ion-input>
+        <ion-select formControlName="region" interface="action-sheet" class="w-full">
+          <ion-select-option *ngFor="let r of regions" [value]="r.name">{{ r.name }}</ion-select-option>
+        </ion-select>
       </ion-item>
       <div *ngIf="profileForm.get('region')?.invalid && profileForm.get('region')?.touched" class="text-xs text-red-500">Campo requerido</div>
+
+      <ion-item class="ion-item-custom">
+        <ion-label position="floating" class="text-sm">Comuna</ion-label>
+        <ion-select formControlName="comuna" interface="action-sheet" class="w-full">
+          <ion-select-option *ngFor="let c of communes" [value]="c">{{ c }}</ion-select-option>
+        </ion-select>
+      </ion-item>
+      <div *ngIf="profileForm.get('comuna')?.invalid && profileForm.get('comuna')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <div *ngIf="errorMsg" class="text-red-500 text-sm text-center">{{ errorMsg }}</div>
 

--- a/frontend/prepmate/src/app/pages/profile/profile.page.ts
+++ b/frontend/prepmate/src/app/pages/profile/profile.page.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ProfileService } from '../../services/profile.service';
+import { REGIONS, Region } from '../../data/regions';
 
 @Component({
   selector: 'app-profile',
@@ -13,6 +14,8 @@ export class ProfilePage implements OnInit {
   profileForm: FormGroup;
   loading = false;
   errorMsg = '';
+  regions: Region[] = REGIONS;
+  communes: string[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -24,11 +27,21 @@ export class ProfilePage implements OnInit {
       comuna: ['', Validators.required],
       region: ['', Validators.required]
     });
+
+    this.profileForm.get('region')?.valueChanges.subscribe(regionName => {
+      const region = this.regions.find(r => r.name === regionName);
+      this.communes = region ? region.communes : [];
+      this.profileForm.get('comuna')?.setValue('');
+    });
   }
 
-  // Inicialmente no se requiere lógica al cargar la vista
-  // eslint-disable-next-line @angular-eslint/no-empty-lifecycle-method
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    const regionName = this.profileForm.get('region')?.value;
+    if (regionName) {
+      const region = this.regions.find(r => r.name === regionName);
+      this.communes = region ? region.communes : [];
+    }
+  }
 
   onSubmit() {
     if (this.profileForm.invalid) {
@@ -44,7 +57,7 @@ export class ProfilePage implements OnInit {
       },
       error: (err) => {
         this.loading = false;
-        this.errorMsg = 'Error al guardar el perfil.';
+        this.errorMsg = err.error?.message || 'Error al guardar el perfil.';
       }
     });
   }

--- a/frontend/prepmate/src/app/pages/session/session-routing.module.ts
+++ b/frontend/prepmate/src/app/pages/session/session-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SessionPage } from './session.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SessionPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SessionPageRoutingModule {}

--- a/frontend/prepmate/src/app/pages/session/session.module.ts
+++ b/frontend/prepmate/src/app/pages/session/session.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { SessionPageRoutingModule } from './session-routing.module';
+import { SessionPage } from './session.page';
+import { ComponentsModule } from '../../components/components.module';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, SessionPageRoutingModule, ComponentsModule],
+  declarations: [SessionPage]
+})
+export class SessionPageModule {}

--- a/frontend/prepmate/src/app/pages/session/session.page.html
+++ b/frontend/prepmate/src/app/pages/session/session.page.html
@@ -1,0 +1,22 @@
+<div class="min-h-screen bg-background-light dark:bg-background-dark text-text-light dark:text-text-dark flex flex-col items-center px-3 py-16 gap-8">
+  <app-logo></app-logo>
+  <div class="w-96 max-w-full bg-white dark:bg-slate-800 px-5 py-4 rounded-2xl shadow-xl" *ngIf="current">
+    <h2 class="text-2xl font-bold text-primary mb-4">{{ materia }}</h2>
+    <p class="progress">Pregunta {{ index + 1 }} de {{ exercises.length }}</p>
+    <p class="font-semibold mb-2">{{ current.title }}</p>
+    <ion-list>
+      <ion-radio-group [(ngModel)]="selected">
+        <ion-item *ngFor="let opt of current.options | keyvalue">
+          <ion-label>{{ opt.key }}. {{ opt.value }}</ion-label>
+          <ion-radio slot="start" [value]="opt.key"></ion-radio>
+        </ion-item>
+      </ion-radio-group>
+    </ion-list>
+    <ion-button class="ion-button-custom mt-4" (click)="submit()">Responder</ion-button>
+  </div>
+  <div *ngIf="done" class="w-96 max-w-full bg-white dark:bg-slate-800 px-5 py-6 rounded-2xl shadow-xl text-center space-y-4">
+    <h2 class="text-xl font-bold text-primary">¡Sesión completada!</h2>
+    <p>Respondiste {{ correct }} de {{ exercises.length }} preguntas correctamente.</p>
+    <ion-button [routerLink]="['/subjects']" class="ion-button-custom mt-2">Volver a materias</ion-button>
+  </div>
+</div>

--- a/frontend/prepmate/src/app/pages/session/session.page.scss
+++ b/frontend/prepmate/src/app/pages/session/session.page.scss
@@ -1,0 +1,3 @@
+.progress {
+  @apply mb-4 text-sm text-text-muted;
+}

--- a/frontend/prepmate/src/app/pages/session/session.page.ts
+++ b/frontend/prepmate/src/app/pages/session/session.page.ts
@@ -1,0 +1,67 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ExerciseService, Exercise } from '../../services/exercise.service';
+import { AssignmentService } from '../../services/assignment.service';
+import { AuthStore } from '../../store/auth.store';
+
+@Component({
+  selector: 'app-session',
+  templateUrl: './session.page.html',
+  styleUrls: ['./session.page.scss'],
+  standalone: false,
+})
+export class SessionPage implements OnInit {
+  materia = '';
+  exercises: Exercise[] = [];
+  index = 0;
+  selected: string | null = null;
+  correct = 0;
+
+  constructor(
+    private route: ActivatedRoute,
+    private exerciseService: ExerciseService,
+    private assignmentService: AssignmentService,
+    private store: AuthStore
+  ) {}
+
+  ngOnInit() {
+    this.materia = this.route.snapshot.paramMap.get('materia') || '';
+    this.exerciseService.getExercisesByMateria(this.materia).subscribe((res) => {
+      this.exercises = res;
+      this.loadCurrent();
+    });
+  }
+
+  get current() {
+    return this.exercises[this.index];
+  }
+
+  get done() {
+    return this.index >= this.exercises.length;
+  }
+
+  loadCurrent() {
+    this.selected = null;
+  }
+
+  submit() {
+    if (!this.current || !this.selected) {
+      return;
+    }
+    const user = this.store['state'].user;
+    const isCorrect = this.selected === this.current.correct_answer;
+    this.assignmentService
+      .submitAssignment({
+        user_id: user.id,
+        exercise_id: this.current.id,
+        respuesta_entregada: this.selected,
+        correcta: isCorrect,
+      })
+      .subscribe();
+    if (isCorrect) {
+      this.correct++;
+    }
+    this.index++;
+    this.loadCurrent();
+  }
+}

--- a/frontend/prepmate/src/app/pages/signup/signup.page.html
+++ b/frontend/prepmate/src/app/pages/signup/signup.page.html
@@ -13,6 +13,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.get('name')?.invalid && signupForm.get('name')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">RUT</ion-label>
@@ -22,6 +23,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.get('rut')?.invalid && signupForm.get('rut')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Edad</ion-label>
@@ -31,6 +33,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.get('age')?.invalid && signupForm.get('age')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Correo electrónico</ion-label>
@@ -40,6 +43,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.get('email')?.invalid && signupForm.get('email')?.touched" class="text-xs text-red-500">Email inválido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Contraseña</ion-label>
@@ -49,6 +53,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.get('password')?.invalid && signupForm.get('password')?.touched" class="text-xs text-red-500">Campo requerido</div>
 
       <ion-item class="ion-item-custom">
         <ion-label position="floating" class="text-sm">Confirmar contraseña</ion-label>
@@ -58,6 +63,7 @@
           class="ion-input-custom w-full text-text-light dark:text-white"
         ></ion-input>
       </ion-item>
+      <div *ngIf="signupForm.hasError('passwordMismatch') && signupForm.get('confirmPassword')?.touched" class="text-xs text-red-500">Las contraseñas no coinciden</div>
 
       <div class="flex items-center gap-2 text-sm text-text-muted">
         <input

--- a/frontend/prepmate/src/app/pages/signup/signup.page.ts
+++ b/frontend/prepmate/src/app/pages/signup/signup.page.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
 import { AuthStore } from '../../store/auth.store';
+import { ErrorService } from '../../services/error.service';
 
 @Component({
   selector: 'app-signup',
@@ -18,7 +19,13 @@ export class SignupPage {
     return password === confirmPassword ? null : { passwordMismatch: true };
   }
 
-  constructor(private fb: FormBuilder, private router: Router, private auth: AuthService, private store: AuthStore) {
+  constructor(
+    private fb: FormBuilder,
+    private router: Router,
+    private auth: AuthService,
+    private store: AuthStore,
+    private error: ErrorService
+  ) {
     this.signupForm = this.fb.group({
       name: ['', Validators.required],
       rut: ['', Validators.required],
@@ -34,19 +41,19 @@ export class SignupPage {
 
   onSubmit() {
     if (this.signupForm.invalid) {
-      console.log('❌ Formulario inválido');
+      this.error.show('Por favor revisa los campos del formulario.');
       return;
     }
 
     const { name, rut, age, email, password, terms } = this.signupForm.value;
-    this.auth.signup({ name, rut, age: Number(age), email, password, terms }).subscribe({
-      next: (res) => {
-        this.store.setSession(res);
-        this.router.navigate(['/subjects']);
-      },
-      error: (err) => {
-        console.error('❌ Error en registro', err);
-      }
-    });
+      this.auth.signup({ name, rut, age: Number(age), email, password, terms }).subscribe({
+        next: (res) => {
+          this.store.setSession(res);
+          this.router.navigate(['/subjects']);
+        },
+        error: (err) => {
+          this.error.handle(err, 'No se pudo completar el registro.');
+        }
+      });
   }
 }

--- a/frontend/prepmate/src/app/pages/subject-select/subject-select.page.ts
+++ b/frontend/prepmate/src/app/pages/subject-select/subject-select.page.ts
@@ -24,6 +24,6 @@ export class SubjectSelectPage implements OnInit {
     const selected = this.subjects.filter(s => s.selected).map(s => s.name);
     if (!selected.length) { return; }
     this.subjectService.saveSelectedSubjects(selected);
-    this.router.navigate(['/exercise', selected[0]]);
+    this.router.navigate(['/session', selected[0]]);
   }
 }

--- a/frontend/prepmate/src/app/services/auth.interceptor.ts
+++ b/frontend/prepmate/src/app/services/auth.interceptor.ts
@@ -10,10 +10,11 @@ import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { TokenService } from './token.service';
 import { Router } from '@angular/router';
+import { ErrorService } from './error.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(private tokenService: TokenService, private router: Router) {}
+  constructor(private tokenService: TokenService, private router: Router, private error: ErrorService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const token = this.tokenService.getToken();
@@ -25,9 +26,13 @@ export class AuthInterceptor implements HttpInterceptor {
     }
     return next.handle(authReq).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401) {
+        const loginOrSignup = authReq.url.endsWith('/auth/login') || authReq.url.endsWith('/auth/signup');
+        if (error.status === 401 && !loginOrSignup) {
           this.tokenService.removeToken();
           this.router.navigate(['/login']);
+          this.error.show(error.error?.message || 'Sesión expirada. Por favor inicia sesión nuevamente.');
+        } else {
+          this.error.show(error.error?.message || 'Ocurrió un error de conexión.');
         }
         return throwError(() => error);
       })

--- a/frontend/prepmate/src/app/services/error.service.ts
+++ b/frontend/prepmate/src/app/services/error.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ErrorService {
+  private messageSubject = new BehaviorSubject<string | null>(null);
+  message$ = this.messageSubject.asObservable();
+
+  show(message: string) {
+    this.messageSubject.next(message);
+  }
+
+  clear() {
+    this.messageSubject.next(null);
+  }
+
+  handle(err: any, fallback = 'Ocurrió un error de conexión.') {
+    const msg = err?.error?.message || err?.message || fallback;
+    this.show(msg);
+  }
+}

--- a/frontend/prepmate/src/app/services/notification.service.ts
+++ b/frontend/prepmate/src/app/services/notification.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private baseUrl = environment.apiUrl + '/api/notifications';
+  private messageSubject = new BehaviorSubject<string | null>(null);
+  message$ = this.messageSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  fetch() {
+    this.http.get<{ message: string }>(this.baseUrl).subscribe({
+      next: (res) => {
+        if (res.message) {
+          this.messageSubject.next(res.message);
+        }
+      },
+      error: () => {}
+    });
+  }
+
+  clear() {
+    this.messageSubject.next(null);
+  }
+}

--- a/frontend/prepmate/src/app/services/progress.service.ts
+++ b/frontend/prepmate/src/app/services/progress.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface SubjectProgress {
+  subject: string;
+  total: number;
+  correct: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ProgressService {
+  private baseUrl = environment.apiUrl + '/api/progress';
+
+  constructor(private http: HttpClient) {}
+
+  getProgress(userId: number): Observable<{ progress: SubjectProgress[] }> {
+    return this.http.get<{ progress: SubjectProgress[] }>(`${this.baseUrl}/${userId}`);
+  }
+}


### PR DESCRIPTION
## Summary
- secure CORS configuration with `flask-cors`
- hash passwords using bcrypt
- sanitize profile and exercise inputs with bleach
- show backend notifications via new banner component
- fetch notifications on app load
- sequential question sessions with new session page
- assignment history endpoint to track answered questions

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome)*
- `pytest --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68588ce722888330b32c4aba4afa7693