### PR TITLE
Seed with base exercises and add view link

### DIFF
--- a/backend/app/api_routes/assignment_routes.py
+++ b/backend/app/api_routes/assignment_routes.py
@@ -9,9 +9,11 @@ assignment_bp = Blueprint('assignment_api', __name__)
 @assignment_bp.route('/api/assignments', methods=['POST'])
 def submit_assignment():
     data = request.json or {}
+    exercise = Exercise.query.get(data.get('exercise_id'))
     assignment = Assignment(
         user_id=data.get('user_id'),
         exercise_id=data.get('exercise_id'),
+        subject_id=exercise.subject_id if exercise else None,
         respuesta_entregada=data.get('respuesta_entregada'),
         correcta=data.get('correcta', False)
     )
@@ -28,7 +30,7 @@ def list_assignments():
     if user_id:
         query = query.filter_by(user_id=user_id)
     if subject_id:
-        query = query.join(Exercise, Assignment.exercise_id == Exercise.id).filter(Exercise.subject_id == subject_id)
+        query = query.filter_by(subject_id=subject_id)
     assignments = query.order_by(Assignment.created_at.desc()).all()
     return (
         jsonify([a.to_dict() for a in assignments]),

--- a/backend/app/api_routes/exercise_routes.py
+++ b/backend/app/api_routes/exercise_routes.py
@@ -7,5 +7,6 @@ exercise_bp = Blueprint('exercise_api', __name__)
 @exercise_bp.route('/api/exercises', methods=['GET'])
 def get_exercises():
     materia = request.args.get('materia')
-    exercises = get_exercises_by_subject(materia)
+    difficulty = request.args.get('difficulty')
+    exercises = get_exercises_by_subject(materia, difficulty)
     return jsonify([e.to_dict() for e in exercises]), 200

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -7,12 +7,14 @@ class Assignment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     exercise_id = db.Column(db.Integer, db.ForeignKey('exercises.id'), nullable=False)
+    subject_id = db.Column(db.Integer, db.ForeignKey('subjects.id'), nullable=False)
     respuesta_entregada = db.Column(db.String(255), nullable=False)
     correcta = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship('User')
-    exercise = db.relationship('Exercise')
+    exercise = db.relationship('Exercise', back_populates='assignments')
+    subject = db.relationship('Subject')
 
     def to_dict(self):
         return {
@@ -22,5 +24,5 @@ class Assignment(db.Model):
             'respuesta_entregada': self.respuesta_entregada,
             'correcta': self.correcta,
             'created_at': self.created_at.isoformat(),
-            'subject_id': self.exercise.subject_id if self.exercise else None,
+            'subject_id': self.subject_id,
         }

--- a/backend/app/models/exercise.py
+++ b/backend/app/models/exercise.py
@@ -15,6 +15,9 @@ class Exercise(db.Model):
 
     subject_id = db.Column(db.Integer, db.ForeignKey('subjects.id'), nullable=False)
     subject = db.relationship('Subject', back_populates='exercises')
+    assignments = db.relationship(
+        'Assignment', back_populates='exercise', cascade='all, delete-orphan'
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/subject.py
+++ b/backend/app/models/subject.py
@@ -1,4 +1,5 @@
 from .. import db
+from .assignment import Assignment
 
 class Subject(db.Model):
     __tablename__ = 'subjects'
@@ -9,3 +10,4 @@ class Subject(db.Model):
     area = db.Column(db.String(120), nullable=True)
 
     exercises = db.relationship('Exercise', back_populates='subject', cascade='all, delete-orphan')
+    assignments = db.relationship('Assignment', back_populates='subject', cascade='all, delete-orphan')

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -1,5 +1,7 @@
 from app.models.exercise import Exercise
 
-
-def get_exercises_by_subject(materia: str):
-    return Exercise.query.join(Exercise.subject).filter_by(name=materia).limit(10).all()
+def get_exercises_by_subject(materia: str, difficulty: str | None = None):
+    query = Exercise.query.join(Exercise.subject).filter_by(name=materia)
+    if difficulty:
+        query = query.filter(Exercise.difficulty == difficulty)
+    return query.limit(10).all()

--- a/backend/app/services/progress_service.py
+++ b/backend/app/services/progress_service.py
@@ -1,6 +1,5 @@
 from sqlalchemy import func, case
 from app.models.assignment import Assignment
-from app.models.exercise import Exercise
 from app.models.subject import Subject
 from app import db
 
@@ -12,8 +11,7 @@ def get_progress_by_user(user_id: int):
             func.count(Assignment.id).label('total'),
             func.sum(case((Assignment.correcta == True, 1), else_=0)).label('correct'),
         )
-        .join(Exercise, Exercise.id == Assignment.exercise_id)
-        .join(Subject, Subject.id == Exercise.subject_id)
+        .join(Subject, Subject.id == Assignment.subject_id)
         .filter(Assignment.user_id == user_id)
         .group_by(Subject.name)
         .all()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,43 +1,181 @@
 from app import create_app, db
 from app.models import Subject, Exercise, Student, Admin
 
+EXERCISE_DATA = [
+    {
+        "subject": "Matemática M1",
+        "level": "fácil",
+        "question": "¿Cuál es el resultado de 25 + 36?",
+        "options": ["51", "61", "71", "81"],
+        "correct": "61",
+        "explanation": "25 + 36 = 61",
+    },
+    {
+        "subject": "Matemática M1",
+        "level": "fácil",
+        "question": "¿Cuál es el doble de 8?",
+        "options": ["14", "16", "18", "20"],
+        "correct": "16",
+        "explanation": "El doble de 8 es 16",
+    },
+    {
+        "subject": "Matemática M1",
+        "level": "media",
+        "question": "¿Cuál es el valor de x en la ecuación 3x - 7 = 11?",
+        "options": ["2", "4", "6", "8"],
+        "correct": "6",
+        "explanation": "3x - 7 = 11 → 3x = 18 → x = 6",
+    },
+    {
+        "subject": "Matemática M1",
+        "level": "difícil",
+        "question": "¿Cuál es el dominio de la función f(x) = √(x - 2)?",
+        "options": ["x ≥ 2", "x > 0", "x ≠ 2", "x < 2"],
+        "correct": "x ≥ 2",
+        "explanation": "La raíz cuadrada solo está definida para x - 2 ≥ 0 → x ≥ 2",
+    },
+    {
+        "subject": "Matemática M2",
+        "level": "fácil",
+        "question": "¿Cuál es la derivada de f(x) = x²?",
+        "options": ["x", "2x", "x²", "2"],
+        "correct": "2x",
+        "explanation": "La derivada de x² es 2x",
+    },
+    {
+        "subject": "Matemática M2",
+        "level": "media",
+        "question": "Calcula el límite de f(x) = (2x² - 3)/(x² + 1) cuando x → ∞",
+        "options": ["2", "0", "1", "Infinito"],
+        "correct": "2",
+        "explanation": "Dividiendo numerador y denominador por x², el límite es 2",
+    },
+    {
+        "subject": "Matemática M2",
+        "level": "difícil",
+        "question": "¿La serie ∑ (1/n²) converge o diverge?",
+        "options": ["Converge", "Diverge", "No se puede determinar", "Es alternante"],
+        "correct": "Converge",
+        "explanation": "Es una serie p con p > 1, por lo tanto converge",
+    },
+    {
+        "subject": "Competencia Lectora",
+        "level": "fácil",
+        "question": "Según el texto, ¿cuál es la idea principal del párrafo 2?",
+        "options": ["A", "B", "C", "D"],
+        "correct": "B",
+        "explanation": "El texto menciona explícitamente la idea en la línea 3 del párrafo",
+    },
+    {
+        "subject": "Competencia Lectora",
+        "level": "media",
+        "question": "¿Cuál es la intención del autor al citar a un experto?",
+        "options": ["Apoyar su argumento", "Contradecirlo", "Introducir un tema", "Desviar la atención"],
+        "correct": "Apoyar su argumento",
+        "explanation": "Usa la cita para respaldar su postura",
+    },
+    {
+        "subject": "Competencia Lectora",
+        "level": "difícil",
+        "question": "¿Cuál de las siguientes afirmaciones es una inferencia válida del texto?",
+        "options": ["A", "B", "C", "D"],
+        "correct": "C",
+        "explanation": "La inferencia se deduce del contexto del último párrafo",
+    },
+    {
+        "subject": "Historia y Ciencias Sociales",
+        "level": "fácil",
+        "question": "¿En qué año ocurrió la Independencia de Chile?",
+        "options": ["1810", "1818", "1833", "1821"],
+        "correct": "1818",
+        "explanation": "La independencia oficial se declaró en 1818",
+    },
+    {
+        "subject": "Historia y Ciencias Sociales",
+        "level": "media",
+        "question": "¿Qué consecuencia tuvo el golpe de Estado de 1973?",
+        "options": ["Democracia inmediata", "Dictadura militar", "Guerra civil", "Reforma agraria"],
+        "correct": "Dictadura militar",
+        "explanation": "El golpe instauró una dictadura que duró hasta 1990",
+    },
+    {
+        "subject": "Historia y Ciencias Sociales",
+        "level": "difícil",
+        "question": "Analiza las implicancias sociales de la Constitución de 1980.",
+        "options": ["A", "B", "C", "D"],
+        "correct": "A",
+        "explanation": "Establece el marco para el modelo neoliberal y restringe la participación política",
+    },
+    {
+        "subject": "Ciencias",
+        "level": "fácil",
+        "question": "¿Cuál es la función principal del sistema respiratorio?",
+        "options": ["Digestión", "Transporte de nutrientes", "Intercambio de gases", "Producción de hormonas"],
+        "correct": "Intercambio de gases",
+        "explanation": "Permite el ingreso de oxígeno y salida de CO₂",
+    },
+    {
+        "subject": "Ciencias",
+        "level": "media",
+        "question": "¿Qué diferencia hay entre una reacción endotérmica y exotérmica?",
+        "options": ["Temperatura", "Luz", "Absorción o liberación de calor", "Color"],
+        "correct": "Absorción o liberación de calor",
+        "explanation": "Endotérmica absorbe calor, exotérmica lo libera",
+    },
+    {
+        "subject": "Ciencias",
+        "level": "difícil",
+        "question": "Explica el principio de conservación de la energía en un circuito cerrado.",
+        "options": ["A", "B", "C", "D"],
+        "correct": "B",
+        "explanation": "La energía total se conserva: la suma de energías es constante",
+    },
+]
+
 
 def seed_data():
     app = create_app()
     with app.app_context():
         db.create_all()
         if not Subject.query.first():
-            subjects = [
-                Subject(name="Matemática M1", description="Matemáticas", area="Mathematics"),
-                Subject(name="Ciencias", description="Área de ciencias", area="Science"),
-                Subject(name="Competencia Lectora", description="Lectura", area="Language"),
-            ]
+            unique_subjects = {ex["subject"] for ex in EXERCISE_DATA}
+            subjects = []
+            for name in unique_subjects:
+                subjects.append(
+                    Subject(
+                        name=name,
+                        description=name,
+                        area=name.split()[0]
+                    )
+                )
             db.session.add_all(subjects)
             db.session.commit()
         else:
             subjects = Subject.query.all()
 
         if not Exercise.query.first():
-            ex_list = [
-                Exercise(
-                    title="¿Cuánto es 1+1?",
-                    description="Suma simple",
-                    options={"A": "1", "B": "2", "C": "3", "D": "4"},
-                    correct_answer="B",
-                    subject_id=subjects[0].id,
-                    difficulty="easy",
-                    tags="aritmetica",
-                ),
-                Exercise(
-                    title="¿Cuál es la capital de Francia?",
-                    description="Pregunta de geografía",
-                    options={"A": "Madrid", "B": "Paris", "C": "Roma", "D": "Lisboa"},
-                    correct_answer="B",
-                    subject_id=subjects[1].id,
-                    difficulty="easy",
-                    tags="geografia",
-                ),
-            ]
+            letters = ["A", "B", "C", "D"]
+            subject_map = {s.name: s.id for s in subjects}
+            ex_list = []
+            for ex in EXERCISE_DATA:
+                if ex["subject"] not in subject_map:
+                    subj = Subject(name=ex["subject"], description=ex["subject"], area=ex["subject"].split()[0])
+                    db.session.add(subj)
+                    db.session.commit()
+                    subject_map[subj.name] = subj.id
+                options = {letters[i]: opt for i, opt in enumerate(ex["options"])}
+                correct_letter = letters[ex["options"].index(ex["correct"])]
+                ex_list.append(
+                    Exercise(
+                        title=ex["question"],
+                        description=ex.get("explanation", ""),
+                        options=options,
+                        correct_answer=correct_letter,
+                        subject_id=subject_map[ex["subject"]],
+                        difficulty=ex.get("level"),
+                        tags="",
+                    )
+                )
             db.session.add_all(ex_list)
             db.session.commit()
 

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -27,6 +27,7 @@ class TestProgressAPI(BaseTestCase):
             assignment = Assignment(
                 user_id=self.user_id,
                 exercise_id=exercise.id,
+                subject_id=subject.id,
                 respuesta_entregada='A',
                 correcta=True,
             )

--- a/frontend/prepmate/src/app/app-routing.module.ts
+++ b/frontend/prepmate/src/app/app-routing.module.ts
@@ -43,6 +43,11 @@ const routes: Routes = [
     path: 'session/:materia',
     loadChildren: () => import('./pages/session/session.module').then(m => m.SessionPageModule),
     canActivate: [AuthGuard]
+  },
+  {
+    path: 'dashboard',
+    loadChildren: () => import('./pages/dashboard/dashboard.module').then(m => m.DashboardPageModule),
+    canActivate: [AuthGuard]
   }
 ];
 

--- a/frontend/prepmate/src/app/home/home.page.ts
+++ b/frontend/prepmate/src/app/home/home.page.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { ThemeService } from '../services/theme.service';
+import { TokenService } from '../services/token.service';
 
 @Component({
   selector: 'app-home',
@@ -7,11 +9,22 @@ import { ThemeService } from '../services/theme.service';
   styleUrls: ['./home.page.scss'],
   standalone: false
 })
-export class HomePage {
+export class HomePage implements OnInit {
   isDark = false;
 
-  constructor(private theme: ThemeService) {
+  constructor(
+    private theme: ThemeService,
+    private tokenService: TokenService,
+    private router: Router,
+  ) {
     this.isDark = this.theme.isDarkMode();
+  }
+
+  ngOnInit() {
+    const token = this.tokenService.getToken();
+    if (token) {
+      this.router.navigate(['/dashboard']);
+    }
   }
 
   toggleDarkMode() {

--- a/frontend/prepmate/src/app/pages/dashboard/dashboard-routing.module.ts
+++ b/frontend/prepmate/src/app/pages/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardPage } from './dashboard.page';
+
+const routes: Routes = [
+  { path: '', component: DashboardPage }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DashboardPageRoutingModule {}

--- a/frontend/prepmate/src/app/pages/dashboard/dashboard.module.ts
+++ b/frontend/prepmate/src/app/pages/dashboard/dashboard.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { DashboardPageRoutingModule } from './dashboard-routing.module';
+import { DashboardPage } from './dashboard.page';
+import { ComponentsModule } from '../../components/components.module';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, DashboardPageRoutingModule, ComponentsModule],
+  declarations: [DashboardPage]
+})
+export class DashboardPageModule {}

--- a/frontend/prepmate/src/app/pages/dashboard/dashboard.page.html
+++ b/frontend/prepmate/src/app/pages/dashboard/dashboard.page.html
@@ -1,0 +1,50 @@
+<div class="min-h-screen bg-background-light dark:bg-background-dark text-text-light dark:text-text-dark flex flex-col items-center px-3 py-16 gap-6">
+  <app-logo></app-logo>
+  <div class="w-full max-w-2xl bg-white dark:bg-slate-800 px-6 py-6 rounded-2xl shadow-xl space-y-6">
+    <h2 class="text-2xl font-bold text-primary mb-4 text-center">Mi Progreso</h2>
+
+    <div class="flex items-center gap-4 summary-card" *ngIf="progress.length">
+      <div class="relative w-24 h-24">
+        <svg class="w-full h-full transform -rotate-90" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="45" stroke-width="10" class="text-slate-200" fill="none"/>
+          <circle cx="50" cy="50" r="45" stroke-width="10" class="text-primary" fill="none"
+            stroke-linecap="round"
+            stroke-dasharray="282"
+            [attr.stroke-dashoffset]="282 - overallPercent * 282"></circle>
+        </svg>
+        <div class="absolute inset-0 flex items-center justify-center font-bold text-xl">
+          {{ (overallPercent * 100) | number:'1.0-0' }}%
+        </div>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold">Progreso total</h3>
+        <p class="text-sm text-text-muted">{{ correct }} correctas de {{ total }} respuestas</p>
+      </div>
+    </div>
+
+    <ng-container *ngIf="progress.length; else noData">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div *ngFor="let p of progress" class="bg-white dark:bg-slate-900 p-4 rounded-xl shadow flex flex-col gap-2">
+          <div class="flex justify-between items-center mb-1">
+            <div class="flex items-center gap-2">
+              <ion-icon [name]="iconFor(p.subject)"></ion-icon>
+              <span class="font-semibold capitalize">{{ p.subject }}</span>
+            </div>
+            <span class="text-sm">{{ p.correct }} / {{ p.total }}</span>
+          </div>
+          <ion-progress-bar [value]="p.total ? p.correct / p.total : 0"></ion-progress-bar>
+          <div class="text-right">
+            <a [routerLink]="['/session', p.subject]" class="text-primary text-sm underline">Practicar</a>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+    <ng-template #noData>
+      <p class="text-center text-sm text-text-muted">Aún no tienes respuestas registradas.</p>
+    </ng-template>
+
+    <div class="text-center text-sm text-text-muted">
+      <a [routerLink]="['/subjects']" class="underline hover:text-primary transition">&larr; Volver a materias</a>
+    </div>
+  </div>
+</div>

--- a/frontend/prepmate/src/app/pages/dashboard/dashboard.page.scss
+++ b/frontend/prepmate/src/app/pages/dashboard/dashboard.page.scss
@@ -1,0 +1,3 @@
+svg circle {
+  transition: stroke-dashoffset 0.5s ease;
+}

--- a/frontend/prepmate/src/app/pages/dashboard/dashboard.page.ts
+++ b/frontend/prepmate/src/app/pages/dashboard/dashboard.page.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { ProgressService, SubjectProgress } from '../../services/progress.service';
+import { AuthStore } from '../../store/auth.store';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.page.html',
+  styleUrls: ['./dashboard.page.scss'],
+  standalone: false
+})
+export class DashboardPage implements OnInit {
+  progress: SubjectProgress[] = [];
+  total = 0;
+  correct = 0;
+
+  constructor(private progressService: ProgressService, private store: AuthStore) {}
+
+  ngOnInit() {
+    const user = this.store['state'].user;
+    this.progressService.getProgress(user.id).subscribe(res => {
+      this.progress = res.progress;
+      this.total = this.progress.reduce((acc, p) => acc + p.total, 0);
+      this.correct = this.progress.reduce((acc, p) => acc + p.correct, 0);
+    });
+  }
+
+  get overallPercent() {
+    return this.total ? this.correct / this.total : 0;
+  }
+
+  iconFor(subject: string) {
+    const name = subject.toLowerCase();
+    if (name.includes('matem')) return 'calculator-outline';
+    if (name.includes('ciencia')) return 'flask-outline';
+    if (name.includes('lectora')) return 'book-outline';
+    if (name.includes('historia')) return 'earth-outline';
+    return 'help-circle-outline';
+  }
+}

--- a/frontend/prepmate/src/app/pages/session/session.page.html
+++ b/frontend/prepmate/src/app/pages/session/session.page.html
@@ -18,5 +18,6 @@
     <h2 class="text-xl font-bold text-primary">¡Sesión completada!</h2>
     <p>Respondiste {{ correct }} de {{ exercises.length }} preguntas correctamente.</p>
     <ion-button [routerLink]="['/subjects']" class="ion-button-custom mt-2">Volver a materias</ion-button>
+    <ion-button [routerLink]="['/dashboard']" fill="outline" class="ion-button-custom mt-2 ml-2">Ver progreso</ion-button>
   </div>
 </div>

--- a/frontend/prepmate/src/app/pages/session/session.page.ts
+++ b/frontend/prepmate/src/app/pages/session/session.page.ts
@@ -16,6 +16,11 @@ export class SessionPage implements OnInit {
   index = 0;
   selected: string | null = null;
   correct = 0;
+  asked = 0;
+  streakCorrect = 0;
+  streakWrong = 0;
+  difficultyLevels = ['fácil', 'media', 'difícil'];
+  difficultyIndex = 0;
 
   constructor(
     private route: ActivatedRoute,
@@ -26,10 +31,21 @@ export class SessionPage implements OnInit {
 
   ngOnInit() {
     this.materia = this.route.snapshot.paramMap.get('materia') || '';
-    this.exerciseService.getExercisesByMateria(this.materia).subscribe((res) => {
-      this.exercises = res;
-      this.loadCurrent();
-    });
+    this.loadExercises();
+  }
+
+  get difficulty() {
+    return this.difficultyLevels[this.difficultyIndex];
+  }
+
+  loadExercises() {
+    this.exerciseService
+      .getExercisesByMateria(this.materia, this.difficulty)
+      .subscribe((res) => {
+        this.exercises = res;
+        this.index = 0;
+        this.loadCurrent();
+      });
   }
 
   get current() {
@@ -37,7 +53,11 @@ export class SessionPage implements OnInit {
   }
 
   get done() {
-    return this.index >= this.exercises.length;
+    return this.asked >= this.maxQuestions;
+  }
+
+  get maxQuestions() {
+    return 10;
   }
 
   loadCurrent() {
@@ -60,8 +80,32 @@ export class SessionPage implements OnInit {
       .subscribe();
     if (isCorrect) {
       this.correct++;
+      this.streakCorrect++;
+      this.streakWrong = 0;
+    } else {
+      this.streakWrong++;
+      this.streakCorrect = 0;
     }
+    this.asked++;
+
+    if (this.streakCorrect >= 2 && this.difficultyIndex < this.difficultyLevels.length - 1) {
+      this.difficultyIndex++;
+      this.streakCorrect = 0;
+      this.loadExercises();
+      return;
+    }
+    if (this.streakWrong >= 2 && this.difficultyIndex > 0) {
+      this.difficultyIndex--;
+      this.streakWrong = 0;
+      this.loadExercises();
+      return;
+    }
+
     this.index++;
-    this.loadCurrent();
+    if (this.index >= this.exercises.length) {
+      this.loadExercises();
+    } else {
+      this.loadCurrent();
+    }
   }
 }

--- a/frontend/prepmate/src/app/pages/subject-select/subject-select.page.html
+++ b/frontend/prepmate/src/app/pages/subject-select/subject-select.page.html
@@ -10,18 +10,27 @@
 
   <ion-card class="ion-card-custom w-96 max-w-full">
     <div class="px-4 py-4 space-y-4">
-      <ion-item class="ion-item-custom" *ngFor="let subject of subjects">
-        <ion-checkbox
-          slot="start"
-          [(ngModel)]="subject.selected"
-          class="ion-checkbox-custom mr-2"
-        ></ion-checkbox>
-        <ion-label class="font-semibold capitalize">{{ subject.name }}</ion-label>
-      </ion-item>
+        <ion-item class="ion-item-custom" *ngFor="let subject of subjects">
+          <ion-checkbox
+            slot="start"
+            [(ngModel)]="subject.selected"
+            class="ion-checkbox-custom mr-2"
+          ></ion-checkbox>
+          <ion-label class="font-semibold capitalize">{{ subject.name }}</ion-label>
+          <ion-button
+            slot="end"
+            fill="clear"
+            size="small"
+            [routerLink]="['/exercise', subject.name]"
+            class="text-primary"
+            >Ver</ion-button>
+        </ion-item>
       <ion-button expand="block" class="ion-button-custom mt-4" (click)="confirmSelection()">Confirmar</ion-button>
     </div>
   </ion-card>
   <div class="mt-4 text-center text-sm text-text-muted">
     <a [routerLink]="['/profile/view']" class="underline hover:text-primary transition">&larr; Volver al perfil</a>
+    <span class="mx-2">|</span>
+    <a [routerLink]="['/dashboard']" class="underline hover:text-primary transition">Ver progreso</a>
   </div>
 </div>

--- a/frontend/prepmate/src/app/services/exercise.service.ts
+++ b/frontend/prepmate/src/app/services/exercise.service.ts
@@ -18,7 +18,11 @@ export class ExerciseService {
 
   constructor(private http: HttpClient) {}
 
-  getExercisesByMateria(materia: string): Observable<Exercise[]> {
-    return this.http.get<Exercise[]>(`${this.baseUrl}/api/exercises?materia=${materia}`);
+  getExercisesByMateria(materia: string, difficulty?: string): Observable<Exercise[]> {
+    const params = [`materia=${materia}`];
+    if (difficulty) {
+      params.push(`difficulty=${difficulty}`);
+    }
+    return this.http.get<Exercise[]>(`${this.baseUrl}/api/exercises?${params.join('&')}`);
   }
 }


### PR DESCRIPTION
## Summary
- seed script now loads a large set of example exercises based on provided JSON
- dynamically create subjects from seed data and insert exercises accordingly
- allow users to quickly view exercises from the subject selection page
- dynamic exercise difficulty logic in session component
- optional difficulty filter for `/api/exercises`
- add simple progress dashboard
- redirect to dashboard from home when a session is active
- **improve dashboard design with summary widget and links to practice**
- **connect assignments directly with subjects for easier querying**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858ca5b8d408330a109ae0c4c87c13f