### PR TITLE
Improve progress display for sessions

### DIFF
--- a/backend/app/controllers/profile_controller.py
+++ b/backend/app/controllers/profile_controller.py
@@ -68,3 +68,33 @@ def get_profile():
     if not student:
         return jsonify({'message': 'Perfil no encontrado'}), 404
     return jsonify({'student': student_schema.dump(student)}), 200
+
+
+@profile_bp.route('/profile/subjects', methods=['PUT'])
+@jwt_required
+def update_selected_subjects():
+    user = g.user
+    if user.role != 'student':
+        return jsonify({'message': 'Solo los estudiantes pueden modificar perfil'}), 403
+    data = request.get_json() or {}
+    subjects = data.get('subjects', [])
+    if not isinstance(subjects, list):
+        return jsonify({'message': 'Formato inválido'}), 400
+    student = Student.query.filter_by(id=user.id).first()
+    if not student:
+        return jsonify({'message': 'Perfil no encontrado'}), 404
+    student.selected_subjects = subjects
+    db.session.commit()
+    return jsonify({'selected_subjects': student.selected_subjects}), 200
+
+
+@profile_bp.route('/profile/subjects', methods=['GET'])
+@jwt_required
+def get_selected_subjects():
+    user = g.user
+    if user.role != 'student':
+        return jsonify({'message': 'Solo los estudiantes pueden ver perfil'}), 403
+    student = Student.query.filter_by(id=user.id).first()
+    if not student:
+        return jsonify({'message': 'Perfil no encontrado'}), 404
+    return jsonify({'selected_subjects': student.selected_subjects or []}), 200

--- a/backend/app/models/student.py
+++ b/backend/app/models/student.py
@@ -12,3 +12,4 @@ class Student(User):
     colegio = db.Column(db.String(120), nullable=True)
     comuna = db.Column(db.String(120), nullable=True)
     region = db.Column(db.String(120), nullable=True)
+    selected_subjects = db.Column(db.JSON, nullable=True, default=list)

--- a/backend/app/schemas/student_schema.py
+++ b/backend/app/schemas/student_schema.py
@@ -16,3 +16,4 @@ class StudentSchema(SQLAlchemySchema):
     colegio = auto_field()
     comuna = auto_field()
     region = auto_field()
+    selected_subjects = auto_field()

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -4,4 +4,4 @@ def get_exercises_by_subject(materia: str, difficulty: str | None = None):
     query = Exercise.query.join(Exercise.subject).filter_by(name=materia)
     if difficulty:
         query = query.filter(Exercise.difficulty == difficulty)
-    return query.limit(10).all()
+    return query.all()

--- a/frontend/prepmate/src/app/pages/session/session.page.html
+++ b/frontend/prepmate/src/app/pages/session/session.page.html
@@ -1,23 +1,29 @@
 <div class="min-h-screen bg-background-light dark:bg-background-dark text-text-light dark:text-text-dark flex flex-col items-center px-3 py-16 gap-8">
   <app-logo></app-logo>
-  <div class="w-96 max-w-full bg-white dark:bg-slate-800 px-5 py-4 rounded-2xl shadow-xl" *ngIf="current">
-    <h2 class="text-2xl font-bold text-primary mb-4">{{ materia }}</h2>
-    <p class="progress">Pregunta {{ index + 1 }} de {{ exercises.length }}</p>
-    <p class="font-semibold mb-2">{{ current.title }}</p>
-    <ion-list>
-      <ion-radio-group [(ngModel)]="selected">
-        <ion-item *ngFor="let opt of current.options | keyvalue">
-          <ion-label>{{ opt.key }}. {{ opt.value }}</ion-label>
-          <ion-radio slot="start" [value]="opt.key"></ion-radio>
-        </ion-item>
-      </ion-radio-group>
-    </ion-list>
-    <ion-button class="ion-button-custom mt-4" (click)="submit()">Responder</ion-button>
-  </div>
+  <ion-card class="ion-card-custom w-96 max-w-full" *ngIf="current">
+    <div class="p-4 space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-xl font-bold text-primary">{{ materia }}</h2>
+        <span class="text-sm text-text-muted">{{ answeredCount + 1 }} / {{ totalExercises }}</span>
+      </div>
+      <ion-progress-bar [value]="answeredCount / totalExercises" aria-label="Progreso de preguntas"></ion-progress-bar>
+      <p class="font-semibold" [innerText]="current.title"></p>
+      <ion-list>
+        <ion-radio-group [(ngModel)]="selected" [attr.aria-label]="current.title" (keyup.enter)="submit()">
+          <ion-item *ngFor="let opt of current.options | keyvalue" lines="full">
+            <ion-label>{{ opt.key }}. {{ opt.value }}</ion-label>
+            <ion-radio slot="start" [value]="opt.key"></ion-radio>
+          </ion-item>
+        </ion-radio-group>
+      </ion-list>
+      <ion-button class="ion-button-custom w-full" (click)="submit()" [disabled]="!selected">Responder</ion-button>
+    </div>
+  </ion-card>
   <div *ngIf="done" class="w-96 max-w-full bg-white dark:bg-slate-800 px-5 py-6 rounded-2xl shadow-xl text-center space-y-4">
     <h2 class="text-xl font-bold text-primary">¡Sesión completada!</h2>
-    <p>Respondiste {{ correct }} de {{ exercises.length }} preguntas correctamente.</p>
-    <ion-button [routerLink]="['/subjects']" class="ion-button-custom mt-2">Volver a materias</ion-button>
-    <ion-button [routerLink]="['/dashboard']" fill="outline" class="ion-button-custom mt-2 ml-2">Ver progreso</ion-button>
+    <p>Respondiste {{ correct }} de {{ answeredCount }} preguntas correctamente.</p>
+    <ion-button class="ion-button-custom" (click)="restart()">Volver a ejercitar</ion-button>
+    <ion-button [routerLink]="['/subjects']" fill="outline" class="ion-button-custom mt-2">Elegir materias</ion-button>
+    <ion-button [routerLink]="['/dashboard']" fill="outline" class="ion-button-custom mt-2">Ver progreso</ion-button>
   </div>
 </div>

--- a/frontend/prepmate/src/app/pages/session/session.page.scss
+++ b/frontend/prepmate/src/app/pages/session/session.page.scss
@@ -1,3 +1,7 @@
-.progress {
-  @apply mb-4 text-sm text-text-muted;
+
+ion-progress-bar {
+  --background: theme('colors.gray.200');
+  --buffer-background: theme('colors.gray.200');
+  --progress-background: theme('colors.teal.500');
+  @apply h-2 rounded-lg mb-2;
 }

--- a/frontend/prepmate/src/app/pages/session/session.page.ts
+++ b/frontend/prepmate/src/app/pages/session/session.page.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ExerciseService, Exercise } from '../../services/exercise.service';
 import { AssignmentService } from '../../services/assignment.service';
 import { AuthStore } from '../../store/auth.store';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-session',
@@ -17,6 +18,8 @@ export class SessionPage implements OnInit {
   selected: string | null = null;
   correct = 0;
   asked = 0;
+  totalExercises = 0;
+  answeredIds = new Set<number>();
   streakCorrect = 0;
   streakWrong = 0;
   difficultyLevels = ['fácil', 'media', 'difícil'];
@@ -26,11 +29,25 @@ export class SessionPage implements OnInit {
     private route: ActivatedRoute,
     private exerciseService: ExerciseService,
     private assignmentService: AssignmentService,
-    private store: AuthStore
+    private store: AuthStore,
+    private toastCtrl: ToastController
   ) {}
+
+  async showResult(correct: boolean) {
+    const toast = await this.toastCtrl.create({
+      message: correct ? '¡Respuesta correcta!' : 'Respuesta incorrecta.',
+      duration: 1500,
+      color: correct ? 'success' : 'danger',
+      position: 'top'
+    });
+    await toast.present();
+  }
 
   ngOnInit() {
     this.materia = this.route.snapshot.paramMap.get('materia') || '';
+    this.exerciseService
+      .getExercisesByMateria(this.materia)
+      .subscribe((res) => (this.totalExercises = res.length));
     this.loadExercises();
   }
 
@@ -56,6 +73,10 @@ export class SessionPage implements OnInit {
     return this.asked >= this.maxQuestions;
   }
 
+  get answeredCount() {
+    return this.answeredIds.size;
+  }
+
   get maxQuestions() {
     return 10;
   }
@@ -78,6 +99,7 @@ export class SessionPage implements OnInit {
         correcta: isCorrect,
       })
       .subscribe();
+    this.showResult(isCorrect);
     if (isCorrect) {
       this.correct++;
       this.streakCorrect++;
@@ -86,7 +108,11 @@ export class SessionPage implements OnInit {
       this.streakWrong++;
       this.streakCorrect = 0;
     }
-    this.asked++;
+
+    if (!this.answeredIds.has(this.current.id)) {
+      this.answeredIds.add(this.current.id);
+      this.asked++;
+    }
 
     if (this.streakCorrect >= 2 && this.difficultyIndex < this.difficultyLevels.length - 1) {
       this.difficultyIndex++;
@@ -107,5 +133,18 @@ export class SessionPage implements OnInit {
     } else {
       this.loadCurrent();
     }
+  }
+
+  restart() {
+    this.correct = 0;
+    this.asked = 0;
+    this.answeredIds.clear();
+    this.streakCorrect = 0;
+    this.streakWrong = 0;
+    this.difficultyIndex = 0;
+    this.exerciseService
+      .getExercisesByMateria(this.materia)
+      .subscribe((res) => (this.totalExercises = res.length));
+    this.loadExercises();
   }
 }

--- a/frontend/prepmate/src/app/pages/subject-select/subject-select.page.ts
+++ b/frontend/prepmate/src/app/pages/subject-select/subject-select.page.ts
@@ -17,6 +17,12 @@ export class SubjectSelectPage implements OnInit {
     this.subjectService.getSubjects().subscribe(res => {
       const arr = (res as any).data || res;
       this.subjects = arr.map((s: any) => ({ ...s, selected: false }));
+      this.subjectService.fetchSelectedSubjects().subscribe(saved => {
+        const selected = saved.selected_subjects || [];
+        this.subjects.forEach(s => {
+          s.selected = selected.includes(s.name);
+        });
+      });
     });
   }
 

--- a/frontend/prepmate/src/app/services/subject.service.ts
+++ b/frontend/prepmate/src/app/services/subject.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class SubjectService {
   private baseUrl = environment.apiUrl + '/subjects';
+  private selectionUrl = environment.apiUrl + '/profile/subjects';
 
   constructor(private http: HttpClient) {}
 
@@ -15,10 +16,19 @@ export class SubjectService {
 
   saveSelectedSubjects(names: string[]) {
     localStorage.setItem('selectedSubjects', JSON.stringify(names));
+    this.updateSelectedSubjects(names).subscribe();
   }
 
   getSelectedSubjects(): string[] {
     const data = localStorage.getItem('selectedSubjects');
     return data ? JSON.parse(data) : [];
+  }
+
+  updateSelectedSubjects(names: string[]) {
+    return this.http.put<{ selected_subjects: string[] }>(this.selectionUrl, { subjects: names });
+  }
+
+  fetchSelectedSubjects() {
+    return this.http.get<{ selected_subjects: string[] }>(this.selectionUrl);
   }
 }


### PR DESCRIPTION
## Summary
- persist user subject preferences and sync with frontend
- show toast feedback for each question and allow restart
- remove query limit when listing exercises
- track progress using unique questions rather than answered count
- redesign session UI with a progress bar

## Testing
- `pytest -q`
- `npm test --silent` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68596e912fbc8330a16870285c6a789f