### PR TITLE
Fix session question flow

### DIFF
--- a/frontend/prepmate/src/app/pages/session/session.page.ts
+++ b/frontend/prepmate/src/app/pages/session/session.page.ts
@@ -59,9 +59,15 @@ export class SessionPage implements OnInit {
     this.exerciseService
       .getExercisesByMateria(this.materia, this.difficulty)
       .subscribe((res) => {
-        this.exercises = res;
+        // filtrar ejercicios ya respondidos
+        this.exercises = res.filter((e) => !this.answeredIds.has(e.id));
         this.index = 0;
-        this.loadCurrent();
+        if (this.exercises.length === 0) {
+          // si no quedan ejercicios pendientes, finalizar la sesión
+          this.asked = this.maxQuestions;
+        } else {
+          this.loadCurrent();
+        }
       });
   }
 
@@ -78,7 +84,7 @@ export class SessionPage implements OnInit {
   }
 
   get maxQuestions() {
-    return 10;
+    return Math.min(10, this.totalExercises);
   }
 
   loadCurrent() {


### PR DESCRIPTION
## Summary
- ignore already answered questions while loading a session
- end a session when no questions remain
- adjust max questions to total exercises

## Testing
- `pytest --cov=app backend/tests/`

------
https://chatgpt.com/codex/tasks/task_e_68597d6f8f888330883dd98d47c1c93a